### PR TITLE
chore: update license references from Apache-2.0 to MIT and organizat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ _Example workflow using the VLM Run node_
 
 ## 📄 License
 
-[Apache-2.0](LICENSE)
+[MIT](LICENSE)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,7 +20,7 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 1. Clone the repository:
    ```
-   git clone git@github.com:autonomi-ai/n8n-nodes-vlmrun.git
+   git clone git@github.com:vlm-run/n8n-nodes-vlmrun.git
    ```
 2. Run `pnpm i` to install dependencies.
 3. Open the project in your editor.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vlm-run/n8n-nodes-vlmrun",
-	"version": "2.1.5",
+	"version": "2.1.6",
 	"description": "VLM Run Nodes for n8n",
 	"keywords": [
 		"n8n-community-node-package"
@@ -13,7 +13,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/autonomi-ai/n8n-nodes-vlmrun.git"
+		"url": "https://github.com/vlm-run/n8n-nodes-vlmrun.git"
 	},
 	"engines": {
 		"node": ">=18.10",


### PR DESCRIPTION
…ion from autonomi-ai to vlm-run (#54)

# chore: update license references from Apache-2.0 to MIT and organization from autonomi-ai to vlm-run

## Summary

This PR updates documentation and configuration files to ensure consistency with the actual MIT license and the organization migration from autonomi-ai to vlm-run. The changes include:

- **README.md**: Updated license reference from `[Apache-2.0](LICENSE)` to `[MIT](LICENSE)` to match the actual LICENSE file content
- **package.json**: Updated repository URL from `autonomi-ai/n8n-nodes-vlmrun` to `vlm-run/n8n-nodes-vlmrun` to reflect the organization migration
- **docs/DEVELOPMENT.md**: Updated clone URL from `autonomi-ai/n8n-nodes-vlmrun` to `vlm-run/n8n-nodes-vlmrun` for consistency

The LICENSE file already contained the correct MIT license text, and package.json already had `"license": "MIT"` set correctly. These changes ensure all documentation references are consistent with the actual license and current organization.

## Review & Testing Checklist for Human

- [ ] **Verify comprehensive coverage**: Search the entire codebase for any remaining "Apache" or "autonomi-ai" references that may have been missed
- [ ] **Test repository URL functionality**: Verify that the new GitHub URLs in package.json and docs work correctly and don't break npm publishing, CI/CD, or other tooling
- [ ] **Check package.json impact**: Ensure the repository field change doesn't affect any automated processes or tooling that depends on this field

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    README["README.md<br/>License Reference"]:::minor-edit
    PKG["package.json<br/>Repository URL"]:::major-edit
    DEV["docs/DEVELOPMENT.md<br/>Clone URL"]:::minor-edit
    LICENSE["LICENSE<br/>(MIT License)"]:::context
    
    README --> LICENSE
    PKG --> LICENSE
    DEV --> LICENSE
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6
    classDef context fill:#FFFFFF
```

### Notes

- The LICENSE file already contained the correct MIT license text, so no changes were needed there
- The package.json already had the correct `"license": "MIT"` field set
- This PR addresses the request to update references from Apache 2.0 to MIT and from autonomi-ai to vlm-run organization
- **Link to Devin run**: https://app.devin.ai/sessions/7c59e0375fb840b18529098cabafe0a8
- **Requested by**: @spillai (Sudeep Pillai)

---------