### PR TITLE
Add Artifacts operation with Agent and Chat support

### DIFF
--- a/nodes/VlmRun/ApiService.ts
+++ b/nodes/VlmRun/ApiService.ts
@@ -174,4 +174,16 @@ export class ApiService {
 		}
 		return client.chat.completions(request);
 	}
+
+	// Artifacts Operations
+	static async getArtifact(
+		ef: IExecuteFunctions,
+		params: {
+			objectId: string;
+			sessionId: string;
+		},
+	): Promise<{ data: Buffer; contentType?: string }> {
+		const client = await this.initializeVlmRun(ef);
+		return client.artifacts.get(params);
+	}
 }

--- a/nodes/VlmRun/ApiService.ts
+++ b/nodes/VlmRun/ApiService.ts
@@ -180,7 +180,8 @@ export class ApiService {
 		ef: IExecuteFunctions,
 		params: {
 			objectId: string;
-			sessionId: string;
+			sessionId?: string;
+			executionId?: string;
 		},
 	): Promise<{ data: Buffer; contentType?: string }> {
 		const client = await this.initializeVlmRun(ef);

--- a/nodes/VlmRun/VlmRun.node.ts
+++ b/nodes/VlmRun/VlmRun.node.ts
@@ -44,12 +44,6 @@ export class VlmRun implements INodeType {
 				noDataExpression: true,
 				options: [
 					{
-						name: 'Artifacts',
-						value: 'artifacts',
-						description: 'Get artifacts by session ID or execution ID and object ID',
-						action: 'Get artifacts',
-					},
-					{
 						name: 'Analyze Audio',
 						value: 'audio',
 						description:
@@ -76,6 +70,12 @@ export class VlmRun implements INodeType {
 						action: 'Analyze video',
 					},
 					{
+						name: 'Artifacts',
+						value: 'artifacts',
+						description: 'Get artifacts by session ID or execution ID and object ID',
+						action: 'Get artifacts',
+					},
+					{
 						name: 'Chat Completion',
 						value: 'chatCompletion',
 						description: 'Generate chat completions using OpenAI-compatible API',
@@ -98,6 +98,30 @@ export class VlmRun implements INodeType {
 		},
 			// Artifacts Properties
 			{
+				displayName: 'Artifact Type',
+				name: 'artifactType',
+				type: 'options',
+				displayOptions: {
+					show: {
+						operation: ['artifacts'],
+					},
+				},
+				options: [
+					{
+						name: 'Agent',
+						value: 'agent',
+						description: 'Get artifact using object ID and execution ID',
+					},
+					{
+						name: 'Chat',
+						value: 'chat',
+						description: 'Get artifact using object ID and session ID',
+					},
+				],
+				default: 'chat',
+				description: 'Type of artifact to retrieve',
+			},
+			{
 				displayName: 'Object ID',
 				name: 'objectId',
 				type: 'string',
@@ -108,7 +132,7 @@ export class VlmRun implements INodeType {
 				},
 				default: '',
 				required: true,
-				description: 'Object ID for the artifact (format: <type>_<6-hex-chars>)',
+				description: 'Object ID for the artifact (format: &lt;type&gt;_&lt;6-hex-chars&gt;)',
 			},
 			{
 				displayName: 'Session ID',
@@ -117,11 +141,26 @@ export class VlmRun implements INodeType {
 				displayOptions: {
 					show: {
 						operation: ['artifacts'],
+						artifactType: ['chat'],
 					},
 				},
 				default: '',
 				required: true,
-				description: 'Session ID for the artifact',
+				description: 'Session ID for the artifact (used with chat type)',
+			},
+			{
+				displayName: 'Execution ID',
+				name: 'executionId',
+				type: 'string',
+				displayOptions: {
+					show: {
+						operation: ['artifacts'],
+						artifactType: ['agent'],
+					},
+				},
+				default: '',
+				required: true,
+				description: 'Execution ID for the artifact (used with agent type)',
 			},
 			// File field for document, image, audio, video operations
 			{
@@ -610,12 +649,22 @@ export class VlmRun implements INodeType {
 
 				switch (operation) {
 					case 'artifacts': {
+						const artifactType = this.getNodeParameter('artifactType', i) as string;
 						const objectId = this.getNodeParameter('objectId', i) as string;
-						const sessionId = this.getNodeParameter('sessionId', i) as string;
+						
+						let sessionId: string | undefined;
+						let executionId: string | undefined;
+
+						if (artifactType === 'agent') {
+							executionId = this.getNodeParameter('executionId', i) as string;
+						} else {
+							sessionId = this.getNodeParameter('sessionId', i) as string;
+						}
 
 						const artifactResponse = await ApiService.getArtifact(this, {
 							objectId,
 							sessionId,
+							executionId,
 						});
 
 						// Determine artifact type from objectId
@@ -657,7 +706,14 @@ export class VlmRun implements INodeType {
 							fileExtension = 'spz';
 							mimeType = 'application/octet-stream';
 						} else if (objType === 'url') {
-							// URL artifact - decode and download
+							// URL artifact - decode and download (only possible when objectId is provided)
+							if (!objectId) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'URL artifacts require an object ID',
+								);
+							}
+							
 							const url = artifactResponse.data.toString('utf-8');
 							
 							try {
@@ -716,7 +772,9 @@ export class VlmRun implements INodeType {
 						}
 
 						// For other types, return as binary data
-						const fileName = `${objectId}.${fileExtension}`;
+						const fileName = objectId 
+							? `${objectId}.${fileExtension}` 
+							: `artifact_${executionId || sessionId}.${fileExtension}`;
 
 						const binaryData = await this.helpers.prepareBinaryData(
 							artifactResponse.data,
@@ -726,9 +784,10 @@ export class VlmRun implements INodeType {
 
 						returnData.push({
 							json: {
-								objectId,
+								objectId: objectId || undefined,
+								executionId: executionId || undefined,
 								sessionId,
-								type: objType,
+								type: objType || 'unknown',
 								filename: fileName,
 							},
 							binary: {

--- a/nodes/VlmRun/config.ts
+++ b/nodes/VlmRun/config.ts
@@ -1,2 +1,5 @@
 export const MAX_ATTEMPTS = 100;
 export const RETRY_DELAY = 5000;
+export const MAX_RETRIES = 3;
+export const DEFAULT_TIMEOUT = 60000; // 60 seconds
+export const CHAT_COMPLETION_TIMEOUT = 240000; // 4 minutes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vlm-run/n8n-nodes-vlmrun",
-	"version": "2.2.11",
+	"version": "2.2.12",
 	"description": "VLM Run Nodes for n8n",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
Adds a new "Artifacts" operation to fetch artifacts from the VLM Run API.

**Features:**
- Supports both Agent (execution_id) and Chat (session_id) artifact types
- Object ID is required for both types
- Returns binary data (images, videos, audio, documents, etc.) compatible with n8n workflows
- Handles URL artifacts by downloading and returning the file
- Uses GET request with JSON body as required by the API

**Input Fields:**
- Object ID (required, both types)
- Session ID (required for Chat)
- Execution ID (required for Agent)