### PR TITLE
feat: Add Artifacts operation with Agent and Chat support

### DIFF
--- a/nodes/VlmRun/ApiService.ts
+++ b/nodes/VlmRun/ApiService.ts
@@ -174,4 +174,17 @@ export class ApiService {
 		}
 		return client.chat.completions(request);
 	}
+
+	// Artifacts Operations
+	static async getArtifact(
+		ef: IExecuteFunctions,
+		params: {
+			objectId: string;
+			sessionId?: string;
+			executionId?: string;
+		},
+	): Promise<{ data: Buffer; contentType?: string }> {
+		const client = await this.initializeVlmRun(ef);
+		return client.artifacts.get(params);
+	}
 }


### PR DESCRIPTION
Adds a new "Artifacts" operation to fetch artifacts from the VLM Run API.

**Features:**
- Supports both Agent (execution_id) and Chat (session_id) artifact types
- Object ID is required for both types
- Returns binary data (images, videos, audio, documents, etc.) compatible with n8n workflows
- Handles URL artifacts by downloading and returning the file
- Uses GET request with JSON body as required by the API

**Input Fields:**
- Object ID (required, both types)
- Session ID (required for Chat)
- Execution ID (required for Agent)